### PR TITLE
implement Clone for ServerName

### DIFF
--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -227,7 +227,7 @@ impl ClientConfig {
 /// # let _: ServerName = x;
 /// ```
 #[non_exhaustive]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum ServerName {
     /// The server is identified by a DNS name.  The name
     /// is sent in the TLS Server Name Indication (SNI)

--- a/rustls/src/msgs/ech.rs
+++ b/rustls/src/msgs/ech.rs
@@ -46,7 +46,13 @@ pub struct EncryptedClientHello {
     // outer_only_exts?
 }
 
-#[derive(Debug)]
+impl Clone for EncryptedClientHello {
+    fn clone(&self) -> Self {
+        Self { hostname: self.hostname.clone(), hpke_params: self.hpke_params.clone(), hpke_info: self.hpke_info.clone(), suite: self.suite.clone(), config_contents: self.config_contents.clone(), inner_message: None, inner_random: self.inner_random.clone(), compressed_extensions: self.compressed_extensions.clone() }
+    }
+}
+
+#[derive(Clone, Debug)]
 pub struct HpkeParams {
     kem: KemAlgorithm,
     kdf: KdfAlgorithm,


### PR DESCRIPTION
The `ServerName` struct should implement `Clone`. When cloning a `ServerName` of type `EncryptedClientHello`, I took a shortcut to skip the cloning of the `inner_message` field by setting it to `None`.